### PR TITLE
Permit symfony/yaml version v7.x OR v8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": "^8.2",
         "illuminate/filesystem": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^7.0|^8.0"
     },
     "require-dev": {
         "laravel/ai": "^0.1.3",


### PR DESCRIPTION
Permit symfony/yaml version v7.x (for PHP <= 8.3) OR v8.x (for PHP >= 8.4)

This is meant to make adding this package to an existing PHP 8.4 project more straightforward since no yaml downgrade will be required.