### PR TITLE
Expose config controls for caching behavior

### DIFF
--- a/config/skills.php
+++ b/config/skills.php
@@ -39,4 +39,20 @@ return [
     'paths' => [
         resource_path('skills'),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Skill Cache
+    |--------------------------------------------------------------------------
+    |
+    | Configure skill discovery cache behavior.
+    |
+    | Set "store" to null to use the application's default cache store.
+    |
+    */
+
+    'cache' => [
+        'enabled' => env('SKILLS_CACHE_ENABLED', ! app()->environment('local', 'testing')),
+        'store' => env('SKILLS_CACHE_STORE', null),
+    ],
 ];

--- a/src/SkillsServiceProvider.php
+++ b/src/SkillsServiceProvider.php
@@ -25,9 +25,25 @@ class SkillsServiceProvider extends ServiceProvider
         }
 
         $this->app->singleton(SkillDiscovery::class, function ($app) {
+            $cacheEnabled = filter_var(
+                config('skills.cache.enabled'),
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            );
+
+            if ($cacheEnabled === null) {
+                $cacheEnabled = ! $app->environment('local', 'testing');
+            }
+
+            $cacheStore = config('skills.cache.store');
+            if (! is_string($cacheStore) || trim($cacheStore) === '') {
+                $cacheStore = null;
+            }
+
             return new SkillDiscovery(
                 paths: config('skills.paths', [resource_path('skills')]),
-                cacheEnabled: ! $app->environment('local', 'testing'),
+                cacheEnabled: $cacheEnabled,
+                cacheStore: $cacheStore,
             );
         });
 

--- a/src/Support/SkillDiscovery.php
+++ b/src/Support/SkillDiscovery.php
@@ -19,12 +19,14 @@ class SkillDiscovery
      * @param  array  $paths  The paths to scan for local skills.
      * @param  bool  $cacheEnabled  Whether to enable caching.
      * @param  int  $cacheTtl  The cache time-to-live in seconds.
+     * @param  string|null  $cacheStore  The cache store to use for skills cache.
      * @return void
      */
     public function __construct(
         protected array $paths,
         protected bool $cacheEnabled = true,
         protected int $cacheTtl = 3600,
+        protected ?string $cacheStore = null,
     ) {}
 
     /**
@@ -60,6 +62,10 @@ class SkillDiscovery
     public function discover(): Collection
     {
         if ($this->cacheEnabled) {
+            if ($this->cacheStore !== null) {
+                return Cache::store($this->cacheStore)->remember('ai_sdk_skills', $this->cacheTtl, fn () => $this->scan());
+            }
+
             return Cache::remember('ai_sdk_skills', $this->cacheTtl, fn () => $this->scan());
         }
 
@@ -84,6 +90,12 @@ class SkillDiscovery
     public function clearCache(): void
     {
         if ($this->cacheEnabled) {
+            if ($this->cacheStore !== null) {
+                Cache::store($this->cacheStore)->forget('ai_sdk_skills');
+
+                return;
+            }
+
             Cache::forget('ai_sdk_skills');
         }
     }

--- a/tests/Feature/SkillsCacheConfigTest.php
+++ b/tests/Feature/SkillsCacheConfigTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AnilcanCakir\LaravelAiSdkSkills\Tests\Feature;
+
+use AnilcanCakir\LaravelAiSdkSkills\Support\SkillDiscovery;
+use AnilcanCakir\LaravelAiSdkSkills\Tests\TestCase;
+use ReflectionClass;
+
+class SkillsCacheConfigTest extends TestCase
+{
+    public function test_missing_cache_config_keeps_legacy_default_behavior()
+    {
+        $skillsConfig = config('skills');
+        unset($skillsConfig['cache']);
+        config(['skills' => $skillsConfig]);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertFalse($this->getProperty($discovery, 'cacheEnabled'));
+        $this->assertNull($this->getProperty($discovery, 'cacheStore'));
+    }
+
+    public function test_cache_enabled_true_forces_cache_on()
+    {
+        config(['skills.cache.enabled' => true]);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertTrue($this->getProperty($discovery, 'cacheEnabled'));
+    }
+
+    public function test_cache_enabled_false_forces_cache_off()
+    {
+        config(['skills.cache.enabled' => false]);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertFalse($this->getProperty($discovery, 'cacheEnabled'));
+    }
+
+    public function test_cache_enabled_invalid_value_falls_back_to_legacy_default()
+    {
+        config(['skills.cache.enabled' => 'not-a-boolean']);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertFalse($this->getProperty($discovery, 'cacheEnabled'));
+    }
+
+    public function test_cache_store_null_uses_default_store()
+    {
+        config(['skills.cache.store' => null]);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertNull($this->getProperty($discovery, 'cacheStore'));
+    }
+
+    public function test_cache_store_setting_is_passed_to_discovery()
+    {
+        config(['skills.cache.store' => 'skills_array']);
+
+        $this->app->forgetInstance(SkillDiscovery::class);
+        $discovery = $this->app->make(SkillDiscovery::class);
+
+        $this->assertSame('skills_array', $this->getProperty($discovery, 'cacheStore'));
+    }
+
+    private function getProperty(SkillDiscovery $discovery, string $name): mixed
+    {
+        $reflection = new ReflectionClass($discovery);
+        $property = $reflection->getProperty($name);
+        $property->setAccessible(true);
+
+        return $property->getValue($discovery);
+    }
+}


### PR DESCRIPTION
This PR exposes explicit control of caching behavior for this package. The main benefit is to enable developers to control caching behavior in their development environment, or they might prefer a particular caching solution for skills vs other general caching needs.