### PR TITLE
Per-skill inclusion mode + simpler skill injection

### DIFF
--- a/config/skills.php
+++ b/config/skills.php
@@ -17,10 +17,11 @@ return [
     | Discovery Mode
     |--------------------------------------------------------------------------
     |
-    | Controls how skills are presented to the AI agent at startup.
+    | Default inclusion mode for skills in prompt instructions.
     |
-    | 'lite': Injects name and description only (saves tokens).
-    | 'full': Injects name, description, and full instructions.
+    | This is used when a skill does not declare its own mode in skills():
+    | - 'lite' (or alias 'lazy'): injects name and description only.
+    | - 'full' (or alias 'eager'): injects full skill instructions.
     |
     */
 

--- a/src/Enums/SkillInclusionMode.php
+++ b/src/Enums/SkillInclusionMode.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AnilcanCakir\LaravelAiSdkSkills\Enums;
+
+enum SkillInclusionMode: string
+{
+    case Lite = 'lite';
+    case Full = 'full';
+
+    /**
+     * Parse enum, canonical strings, and alias strings.
+     */
+    public static function tryFromInput(mixed $value): ?self
+    {
+        if ($value instanceof self) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return match ($normalized) {
+            'lite', 'lazy' => self::Lite,
+            'full', 'eager' => self::Full,
+            default => null,
+        };
+    }
+}

--- a/src/Traits/Skillable.php
+++ b/src/Traits/Skillable.php
@@ -108,6 +108,9 @@ trait Skillable
      * Compose full system instructions with skill instructions inserted in the middle.
      *
      * The dynamic prompt is appended last for prompt-caching-friendly ordering.
+     *
+     * @param  string  $staticPrompt  The stable/base system prompt content to place first.
+     * @param  string  $dynamicPrompt  Runtime-varying prompt content to append at the end.
      */
     public function withSkillInstructions(string $staticPrompt, string $dynamicPrompt = ''): string
     {

--- a/tests/Feature/SkillableTraitTest.php
+++ b/tests/Feature/SkillableTraitTest.php
@@ -2,10 +2,12 @@
 
 namespace AnilcanCakir\LaravelAiSdkSkills\Tests\Feature;
 
+use AnilcanCakir\LaravelAiSdkSkills\Enums\SkillInclusionMode;
 use AnilcanCakir\LaravelAiSdkSkills\Support\SkillRegistry;
 use AnilcanCakir\LaravelAiSdkSkills\Tests\TestCase;
 use AnilcanCakir\LaravelAiSdkSkills\Traits\Skillable;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 
 class SkillableTraitTest extends TestCase
 {
@@ -186,5 +188,216 @@ EOT
         $this->assertEmpty($tools);
         $this->assertEmpty($instructions);
         $this->assertFalse(resolve(SkillRegistry::class)->isLoaded('test-skill'));
+    }
+
+    public function test_with_skill_instructions_composes_static_skill_dynamic_in_order()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('ordered-skill', 'Ordered skill', 'Ordered instructions.');
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return ['ordered-skill'];
+            }
+        };
+
+        $prompt = $agent->withSkillInstructions(
+            'Base instructions...',
+            'Runtime context goes last.'
+        );
+
+        $skillPosition = strpos($prompt, '<skill name="ordered-skill"');
+        $runtimePosition = strpos($prompt, 'Runtime context goes last.');
+
+        $this->assertNotFalse($skillPosition);
+        $this->assertNotFalse($runtimePosition);
+        $this->assertGreaterThan($skillPosition, $runtimePosition);
+        $this->assertStringStartsWith('Base instructions...', $prompt);
+        $this->assertStringEndsWith('Runtime context goes last.', $prompt);
+
+        $this->deleteFixtureSkill('ordered-skill');
+    }
+
+    public function test_with_skill_instructions_without_dynamic_prompt_joins_cleanly()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('join-skill', 'Join skill', 'Join instructions.');
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return ['join-skill'];
+            }
+        };
+
+        $skillsBlock = $agent->skillInstructions();
+        $prompt = $agent->withSkillInstructions('Base instructions...');
+
+        $this->assertSame("Base instructions...\n\n{$skillsBlock}", $prompt);
+        $this->assertStringNotContainsString("\n\n\n", $prompt);
+
+        $this->deleteFixtureSkill('join-skill');
+    }
+
+    public function test_with_skill_instructions_handles_disabled_skills_without_skill_block()
+    {
+        config(['skills.enabled' => false]);
+
+        $agent = new class
+        {
+            use Skillable;
+        };
+
+        $prompt = $agent->withSkillInstructions(
+            'Base instructions...',
+            'Runtime context goes last.'
+        );
+
+        $this->assertSame(
+            "Base instructions...\n\nRuntime context goes last.",
+            $prompt
+        );
+    }
+
+    public function test_mixed_per_skill_modes_use_explicit_value_or_config_fallback()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('explicit-full-skill', 'Explicit full skill', 'Show me fully.');
+        $this->createFixtureSkill('fallback-lite-skill', 'Fallback lite skill', 'Hide me by default.');
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [
+                    'explicit-full-skill' => 'full',
+                    'fallback-lite-skill',
+                ];
+            }
+        };
+
+        $instructions = $agent->skillInstructions();
+
+        $this->assertStringContainsString('<skill name="explicit-full-skill">', $instructions);
+        $this->assertStringContainsString('Show me fully.', $instructions);
+        $this->assertStringContainsString('<skill name="fallback-lite-skill" description="Fallback lite skill" />', $instructions);
+        $this->assertStringNotContainsString('Hide me by default.', $instructions);
+
+        $this->deleteFixtureSkill('explicit-full-skill');
+        $this->deleteFixtureSkill('fallback-lite-skill');
+    }
+
+    public function test_per_skill_alias_modes_are_supported()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('lazy-skill', 'Lazy skill', 'Should stay hidden.');
+        $this->createFixtureSkill('eager-skill', 'Eager skill', 'Should be visible.');
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [
+                    'lazy-skill' => 'lazy',
+                    'eager-skill' => 'eager',
+                ];
+            }
+        };
+
+        $instructions = $agent->skillInstructions();
+
+        $this->assertStringContainsString('description="Lazy skill"', $instructions);
+        $this->assertStringNotContainsString('Should stay hidden.', $instructions);
+        $this->assertStringContainsString('<skill name="eager-skill">', $instructions);
+        $this->assertStringContainsString('Should be visible.', $instructions);
+
+        $this->deleteFixtureSkill('lazy-skill');
+        $this->deleteFixtureSkill('eager-skill');
+    }
+
+    public function test_per_skill_enum_modes_are_supported()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('enum-skill', 'Enum skill', 'Enum full instructions.');
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [
+                    'enum-skill' => SkillInclusionMode::Full,
+                ];
+            }
+        };
+
+        $instructions = $agent->skillInstructions();
+
+        $this->assertStringContainsString('<skill name="enum-skill">', $instructions);
+        $this->assertStringContainsString('Enum full instructions.', $instructions);
+
+        $this->deleteFixtureSkill('enum-skill');
+    }
+
+    public function test_invalid_per_skill_mode_logs_warning_and_falls_back_to_config()
+    {
+        config(['skills.discovery_mode' => 'lite']);
+        $this->createFixtureSkill('invalid-mode-skill', 'Invalid mode skill', 'Should stay hidden by fallback.');
+
+        Log::shouldReceive('warning')->atLeast()->once();
+
+        $agent = new class
+        {
+            use Skillable;
+
+            public function skills(): iterable
+            {
+                return [
+                    'invalid-mode-skill' => 'fast',
+                ];
+            }
+        };
+
+        $instructions = $agent->skillInstructions();
+
+        $this->assertStringContainsString('description="Invalid mode skill"', $instructions);
+        $this->assertStringNotContainsString('Should stay hidden by fallback.', $instructions);
+
+        $this->deleteFixtureSkill('invalid-mode-skill');
+    }
+
+    private function createFixtureSkill(string $slug, string $description, string $instructions): void
+    {
+        $skillPath = __DIR__.'/../fixtures/skills/'.$slug;
+        if (! File::exists($skillPath)) {
+            File::makeDirectory($skillPath, 0755, true);
+        }
+
+        File::put($skillPath.'/SKILL.md', <<<EOT
+---
+name: {$slug}
+description: {$description}
+---
+# Instructions
+{$instructions}
+EOT
+        );
+    }
+
+    private function deleteFixtureSkill(string $slug): void
+    {
+        File::deleteDirectory(__DIR__.'/../fixtures/skills/'.$slug);
     }
 }


### PR DESCRIPTION
This PR adds two separate but related features:

## Per-skill inclusion mode selection

```php
use AnilcanCakir\LaravelAiSdkSkills\Enums\SkillInclusionMode;

public function skills(): iterable
{
    return [
        'style-guide' => SkillInclusionMode::Full,
        'doc-writer' => SkillInclusionMode::Lite,
        'tools-guide' => 'full', // string input
        'api-writer' => 'eager', // alias for full
        'qa-checker' => 'lazy',  // alias for lite
        'doc-writer',            // uses config('skills.discovery_mode')
    ];
}
```

This allows selective determination about what to include in the system prompt immediately. This encourages writing snippets that would be included in many system prompts as skills to improve reusability.

## Simpler skill injection

A new method for injecting the skills data is included:

```php
    public function instructions(): string
    {
        return $this->withSkillInstructions(
            staticPrompt: "Base instructions...",
            dynamicPrompt: "Conversation-specific context goes at the end."
        );
    }
```

This solution is designed to encourage best-practice behavior for injecting per-call variable content at the end of the message. This is necessary to maximize the gains from automatic caching by LLMs (mostly OpenAI right now). It also eliminates the need to append the output of the function to the instructions, or to understand what best practice would be.